### PR TITLE
FIX: restore alumni and collaborator titles

### DIFF
--- a/_pages/team.md
+++ b/_pages/team.md
@@ -90,34 +90,15 @@ Jump to [staff](#staff), [master and bachelor students](#master-and-bachelor-stu
 <div class="col-sm-6 clearfix">
 
 <!-- Card -->
-<div class="card mb-3 border-0">
-<div class="row g-0">
-<div class="col-md-4">
-</div>
-<div class="col-md-8">
-<div class="card-body">
+<div class="mb-3">
 <h5 class="card-title">{{ member.name }}</h5>
 {% if member.title %}
-<h6 class="card-subtitle mb-2 text-muted">{{ member.title }}</h6>
-{% endif %}
-{% if member.email %}
-<p class="card-text">email: <{{ member.email }}></p>
+<p class="text-muted mb-1">{{ member.title }}</p>
 {% endif %}
 {% if member.links %}
 <p class="card-text"><small>{% for link in member.links %}{{ link }}{% unless forloop.last %} | {% endunless %}{% endfor %}</small></p>
 {% endif %}
 </div>
-</div>
-</div>
-</div>
-
-{% if member.education %}
-<ul style="overflow: hidden">
-{% for edu_item in member.education %}
-<li> {{ edu_item }} </li>
-{% endfor %}
-</ul>
-{% endif %}
 </div>
 
 {% assign number_printed = number_printed | plus: 1 %}
@@ -148,39 +129,15 @@ Jump to [staff](#staff), [master and bachelor students](#master-and-bachelor-stu
 <div class="col-sm-6 clearfix">
 
 <!-- Card -->
-<div class="card mb-3 border-0">
-<div class="row g-0">
-<div class="col-md-4">
-<img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-fluid rounded-start" alt="{{ member.name }}">
-</div>
-<div class="col-md-8">
-<div class="card-body">
+<div class="mb-3">
 <h5 class="card-title">{{ member.name }}</h5>
 {% if member.title %}
-<h6 class="card-subtitle mb-2 text-muted">{{ member.title }}</h6>
-{% endif %}
-{% if member.email %}
-<p class="card-text">email: <{{ member.email }}></p>
+<p class="text-muted mb-1">{{ member.title }}</p>
 {% endif %}
 {% if member.links %}
 <p class="card-text"><small>{% for link in member.links %}{{ link }}{% unless forloop.last %} | {% endunless %}{% endfor %}</small></p>
 {% endif %}
 </div>
-</div>
-</div>
-</div>
-
-{% if member.bio %}
-<p><small>{{ member.bio }}</small></p>
-{% endif %}
-
-{% if member.education %}
-<ul style="overflow: hidden">
-{% for edu_item in member.education %}
-<li> {{ edu_item }} </li>
-{% endfor %}
-</ul>
-{% endif %}
 </div>
 
 {% assign number_printed = number_printed | plus: 1 %}


### PR DESCRIPTION
## Summary
- restore display of titles for alumni while keeping name-and-links layout
- show collaborator titles alongside names and links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ca0a7fbc83308ce60ac4b8db7cd7)